### PR TITLE
Redesign homepage with tier-list view, category filters, and centered…

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,8 @@
+RUBY := /usr/local/opt/ruby/bin
+export PATH := $(RUBY):$(PATH)
+
 run-server:
-	bundle exec jekyll serve
+	bundle exec jekyll serve --livereload --watch
 
 build:
 	bundle exec jekyll build

--- a/_posts/2013-08-23-itinerary.md
+++ b/_posts/2013-08-23-itinerary.md
@@ -1,11 +1,11 @@
 ---
 layout: post
 title: 2013 Backpacking Itinerary
-date: '2013-08-23T03:31:00.003-04:00'
+date: 2013-08-23T03:31:00.003-04:00
 author: Doug Hindson
 tags:
-- facts and data
-modified_time: '2014-01-15T17:55:18.887-05:00'
+  - d-tier
+modified_time: 2014-01-15T17:55:18.887-05:00
 blogger_id: tag:blogger.com,1999:blog-3762968903344452987.post-4502190468310688330
 blogger_orig_url: https://www.curiousest.com/2013/08/itinerary.html
 ---

--- a/_posts/2013-08-28-one-day-of-travel.md
+++ b/_posts/2013-08-28-one-day-of-travel.md
@@ -1,11 +1,12 @@
 ---
 layout: post
 title: One day of travel
-date: '2013-08-28T05:05:00.004-04:00'
+date: 2013-08-28T05:05:00.004-04:00
 author: Doug Hindson
 tags:
-- blog
-modified_time: '2013-08-28T22:43:52.882-04:00'
+  - blog
+  - d-tier
+modified_time: 2013-08-28T22:43:52.882-04:00
 blogger_id: tag:blogger.com,1999:blog-3762968903344452987.post-8861877115330897139
 blogger_orig_url: https://www.curiousest.com/2013/08/one-day-of-travel.html
 ---

--- a/_posts/2013-09-24-a-day-of-my-life-in-batu-karas.md
+++ b/_posts/2013-09-24-a-day-of-my-life-in-batu-karas.md
@@ -1,11 +1,12 @@
 ---
 layout: post
 title: A Day of My Life in Batu Karas
-date: '2013-09-24T22:56:00.000-04:00'
+date: 2013-09-24T22:56:00.000-04:00
 author: Doug Hindson
 tags:
-- blog
-modified_time: '2013-09-24T22:56:11.346-04:00'
+  - blog
+  - d-tier
+modified_time: 2013-09-24T22:56:11.346-04:00
 thumbnail: https://4.bp.blogspot.com/-55IOJNmIDWc/UkJHG4U-4nI/AAAAAAAAAPo/tELmv2i8E7w/s72-c/IMAG0592.jpg
 blogger_id: tag:blogger.com,1999:blog-3762968903344452987.post-6702113905621644453
 blogger_orig_url: https://www.curiousest.com/2013/09/a-day-of-my-life-in-batu-karas.html

--- a/_posts/2013-10-18-desensitized.md
+++ b/_posts/2013-10-18-desensitized.md
@@ -1,12 +1,13 @@
 ---
 layout: post
 title: Desensitized
-date: '2013-10-18T12:29:00.003-04:00'
+date: 2013-10-18T12:29:00.003-04:00
 author: Doug Hindson
 tags:
-- essay
-- blog
-modified_time: '2013-10-18T12:50:42.774-04:00'
+  - essay
+  - blog
+  - d-tier
+modified_time: 2013-10-18T12:50:42.774-04:00
 blogger_id: tag:blogger.com,1999:blog-3762968903344452987.post-5536214378171088618
 blogger_orig_url: https://www.curiousest.com/2013/10/HowILearnedtoStopCaring.html
 ---

--- a/_posts/2013-11-03-vipassana-1.md
+++ b/_posts/2013-11-03-vipassana-1.md
@@ -1,13 +1,14 @@
 ---
 layout: post
-title: 'Vipassana: 10 Days'' Meditation (Part 1/3)'
-date: '2013-11-03T10:10:00.000-05:00'
+title: "Vipassana: 10 Days' Meditation (Part 1/3)"
+date: 2013-11-03T10:10:00.000-05:00
 author: Doug Hindson
-tags: 
-- favourite
-- blog
-- vipassana
-modified_time: '2013-12-12T22:29:51.478-05:00'
+tags:
+  - favourite
+  - blog
+  - vipassana
+  - c-tier
+modified_time: 2013-12-12T22:29:51.478-05:00
 thumbnail: https://1.bp.blogspot.com/-5iQCaQjMESQ/UnZq9M4q6AI/AAAAAAAAARY/LxCE9Vr2yzc/s72-c/IMAG0738.jpg
 blogger_id: tag:blogger.com,1999:blog-3762968903344452987.post-2469252930754264669
 blogger_orig_url: https://www.curiousest.com/2013/11/vipassana-10-days-meditation-part-13.html

--- a/_posts/2013-11-06-vipassana-2.md
+++ b/_posts/2013-11-06-vipassana-2.md
@@ -1,12 +1,13 @@
 ---
 layout: post
-title: 'Vipassana: 10 Days'' Meditation (Part 2/3)'
-date: '2013-11-06T01:56:00.000-05:00'
+title: "Vipassana: 10 Days' Meditation (Part 2/3)"
+date: 2013-11-06T01:56:00.000-05:00
 author: Doug Hindson
 tags:
-- blog
-- vipassana
-modified_time: '2013-12-12T22:28:23.409-05:00'
+  - blog
+  - vipassana
+  - d-tier
+modified_time: 2013-12-12T22:28:23.409-05:00
 thumbnail: https://4.bp.blogspot.com/-s2hfjonID_0/UnndfczzRoI/AAAAAAAAARw/TVjQOaoVTkc/s72-c/IMAG0757%5B1%5D.jpg
 blogger_id: tag:blogger.com,1999:blog-3762968903344452987.post-72417128344390393
 blogger_orig_url: https://www.curiousest.com/2013/11/vipassana-10-days-meditation-part-23.html

--- a/_posts/2013-12-12-vipassana-3.md
+++ b/_posts/2013-12-12-vipassana-3.md
@@ -1,12 +1,13 @@
 ---
 layout: post
-title: 'Vipassana: 10 Days'' Meditation (Part 3/3)'
-date: '2013-12-12T22:25:00.002-05:00'
+title: "Vipassana: 10 Days' Meditation (Part 3/3)"
+date: 2013-12-12T22:25:00.002-05:00
 author: Doug Hindson
 tags:
-- blog
-- vipassana
-modified_time: '2013-12-12T22:25:42.687-05:00'
+  - blog
+  - vipassana
+  - d-tier
+modified_time: 2013-12-12T22:25:42.687-05:00
 thumbnail: https://2.bp.blogspot.com/-HuPpVRsiytg/Uqp3zJ-0F8I/AAAAAAAAASM/NhMf6PEBkbI/s72-c/IMAG0761.jpg
 blogger_id: tag:blogger.com,1999:blog-3762968903344452987.post-3372162853601718515
 blogger_orig_url: https://www.curiousest.com/2013/12/vipassana-10-days-meditation-part-33.html

--- a/_posts/2013-12-17-farmer-tan.md
+++ b/_posts/2013-12-17-farmer-tan.md
@@ -1,13 +1,14 @@
 ---
 layout: post
 title: Farmer Tan
-date: '2013-12-17T16:50:00.000-05:00'
+date: 2013-12-17T16:50:00.000-05:00
 author: Doug Hindson
-tags: 
-- favourite
-- story
-- blog
-modified_time: '2013-12-17T16:50:47.073-05:00'
+tags:
+  - favourite
+  - story
+  - blog
+  - b-tier
+modified_time: 2013-12-17T16:50:47.073-05:00
 thumbnail: https://2.bp.blogspot.com/-4zCcVyKTY4w/UrDB0_Tj9OI/AAAAAAAAASc/KYde-hMwEys/s72-c/IMAG0857.jpg
 blogger_id: tag:blogger.com,1999:blog-3762968903344452987.post-6490256988386727697
 blogger_orig_url: https://www.curiousest.com/2013/12/farmer-tan.html

--- a/_posts/2014-01-13-an-elaborate-proposition.md
+++ b/_posts/2014-01-13-an-elaborate-proposition.md
@@ -1,12 +1,13 @@
 ---
 layout: post
 title: An Elaborate Proposition
-date: '2014-01-13T10:13:00.000-05:00'
+date: 2014-01-13T10:13:00.000-05:00
 author: Doug Hindson
-tags: 
-- favourite
-- story
-modified_time: '2014-11-30T10:32:12.785-05:00'
+tags:
+  - favourite
+  - story
+  - b-tier
+modified_time: 2014-11-30T10:32:12.785-05:00
 ---
 
 I'm on a first date in Shanghai. It's just past eleven and we've finished our drinks. She's a Chinese-American girl who runs an art-design-tech startup. She's intense, super cute, and not at all what I expected. I don't know what I expected, but she's better.

--- a/_posts/2014-01-18-my-opinion-of-cities-i-visited.md
+++ b/_posts/2014-01-18-my-opinion-of-cities-i-visited.md
@@ -1,10 +1,11 @@
 ---
 layout: post
 title: My Opinion of the Cities I Visited
-date: '2014-01-18T12:53:00.000-05:00'
+date: 2014-01-18T12:53:00.000-05:00
 author: Doug Hindson
 tags:
-modified_time: '2014-01-18T12:55:17.974-05:00'
+  - d-tier
+modified_time: 2014-01-18T12:55:17.974-05:00
 thumbnail: https://3.bp.blogspot.com/-Qxqh8AV1XhA/Utq-MxEPVfI/AAAAAAAAAUk/_S1pQzfdYG0/s72-c/Screenshot+from+2014-01-18+16:19:30.png
 blogger_id: tag:blogger.com,1999:blog-3762968903344452987.post-8167292371862107731
 blogger_orig_url: https://www.curiousest.com/2014/01/my-opinion-of-cities-i-visited.html

--- a/_posts/2014-01-24-i-hate-cars-and-chewing-is-redundant.md
+++ b/_posts/2014-01-24-i-hate-cars-and-chewing-is-redundant.md
@@ -1,11 +1,12 @@
 ---
 layout: post
 title: I Hate Cars and Chewing is Redundant
-date: '2014-01-24T11:50:00.000-05:00'
+date: 2014-01-24T11:50:00.000-05:00
 author: Doug Hindson
 tags:
-- essay
-modified_time: '2014-11-30T10:20:25.427-05:00'
+  - essay
+  - c-tier
+modified_time: 2014-11-30T10:20:25.427-05:00
 ---
 
 ### Imagine:

--- a/_posts/2014-03-23-so-china-is-bad.md
+++ b/_posts/2014-03-23-so-china-is-bad.md
@@ -1,11 +1,12 @@
 ---
 layout: post
 title: So China is Bad
-date: '2014-03-23T09:28:00.000-04:00'
+date: 2014-03-23T09:28:00.000-04:00
 author: Doug Hindson
 tags:
-- essay
-modified_time: '2014-03-23T19:57:25.043-04:00'
+  - essay
+  - c-tier
+modified_time: 2014-03-23T19:57:25.043-04:00
 ---
 
 I thought China was bad. I think China is bad. I'm here and things don't seem so bad, so something's up. I began to think about why I think about China so negatively. All the Chinese people I've known in Canada have been so wonderful and Chinese culture is so unoffensive. I realized that all the negative things I think about China comes from Western media and its regurgitation.

--- a/_posts/2017-03-15-dream-girl-fading.md
+++ b/_posts/2017-03-15-dream-girl-fading.md
@@ -1,11 +1,12 @@
 ---
 layout: post
 title: Dream Girl Fading
-date: '2017-03-15T11:52:00.001-05:00'
+date: 2017-03-15T11:52:00.001-05:00
 author: Douglas Hindson
-tags: 
-- story
-modified_time: '2017-03-15T11:52:00.001-05:00'
+tags:
+  - story
+  - d-tier
+modified_time: 2017-03-15T11:52:00.001-05:00
 ---
 
 WORK IN PROGRESS

--- a/_posts/2017-05-29-comparing-air-pollution-indexes.md
+++ b/_posts/2017-05-29-comparing-air-pollution-indexes.md
@@ -1,13 +1,12 @@
 ---
 layout: post
 title: Comparing air pollution indexes
-date: '2017-05-29T15:22:00.001-05:00'
+date: 2017-05-29T15:22:00.001-05:00
 author: Douglas Hindson
 tags:
-- O2Canada
-- air pollution
-- facts and data
-modified_time: '2017-05-30T15:22:00.001-05:00'
+  - O2Canada
+  - d-tier
+modified_time: 2017-05-30T15:22:00.001-05:00
 ---
 
 [There are a lot of air pollution indexes](#there-are-a-lot-of-air-pollution-indexes). [Air quality over time is hard to express](#air-quality-over-time-is-hard-to-express) and [indexes can use different combinations of particles](#indexes-can-use-different-combinations-of-particles), so one governing body often has multiple air quality indexes.

--- a/_posts/2017-06-13-evolution-of-my-desk.md
+++ b/_posts/2017-06-13-evolution-of-my-desk.md
@@ -1,14 +1,15 @@
 ---
 layout: post
 title: Evolution of my desk part 1
-date: '2017-06-13T11:52:00.001-05:00'
+date: 2017-06-13T11:52:00.001-05:00
 author: Douglas Hindson
-tags: 
-- DIY
-- blog
-- favourite
-- projects
-modified_time: '2017-06-13T11:52:00.001-05:00'
+tags:
+  - DIY
+  - blog
+  - favourite
+  - project
+  - a-tier
+modified_time: 2017-06-13T11:52:00.001-05:00
 ---
 
 tl;dr I experimented with my keyboard and computer setup. [Imgur album](https://imgur.com/a/qWvI0). Initially, I thought this would be a good idea:

--- a/_posts/2018-11-11-evolution-of-my-desk-2.md
+++ b/_posts/2018-11-11-evolution-of-my-desk-2.md
@@ -1,14 +1,15 @@
 ---
 layout: post
-title: 'Evolution of my desk part 2: sound-proofing'
-date: '2018-11-11T11:00:00.001-05:00'
+title: "Evolution of my desk part 2: sound-proofing"
+date: 2018-11-11T11:00:00.001-05:00
 author: Douglas Hindson
-tags: 
-- DIY
-- blog
-- projects
-- sound
-modified_time: '2018-11-11T11:00:00.001-05:00'
+tags:
+  - DIY
+  - blog
+  - project
+  - sound
+  - d-tier
+modified_time: 2018-11-11T11:00:00.001-05:00
 ---
 
 [Part 1 - on keyboards](/2017/06/13/evolution-of-my-desk.html)

--- a/_posts/2019-05-30-parable-patriarchy-chicken.md
+++ b/_posts/2019-05-30-parable-patriarchy-chicken.md
@@ -9,6 +9,7 @@ tags:
   - essay
   - favourite
   - feminism
+  - c-tier
 modified_time: 2019-06-17T00:00:00.001-05:00
 ---
 

--- a/_posts/2019-06-18-time-management-calendar-fully-booked.md
+++ b/_posts/2019-06-18-time-management-calendar-fully-booked.md
@@ -1,11 +1,12 @@
 ---
 layout: post
 title: "Time management for personal life: a fully booked calendar"
-date: '2019-06-18T00:00:00.001-05:00'
+date: 2019-06-18T00:00:00.001-05:00
 author: Douglas Hindson
-tags: 
-- lifehacking
-modified_time: '2019-06-18T00:00:00.001-05:00'
+tags:
+  - lifehacking
+  - d-tier
+modified_time: 2019-06-18T00:00:00.001-05:00
 ---
 
 I've been trialing a time management strategy: a fully booked calendar for my personal life.

--- a/_posts/2019-07-07-cutting-dieting-fasting.md
+++ b/_posts/2019-07-07-cutting-dieting-fasting.md
@@ -1,12 +1,13 @@
 ---
 layout: post
-title: "Cutting, dieting, fasting"
-date: '2019-07-07T00:00:00.001-05:00'
+title: Cutting, dieting, fasting
+date: 2019-07-07T00:00:00.001-05:00
 author: Douglas Hindson
-tags: 
-- blog
-- fitness
-modified_time: '2020-02-01T00:00:00.001-05:00'
+tags:
+  - blog
+  - fitness
+  - d-tier
+modified_time: 2020-02-01T00:00:00.001-05:00
 ---
 
 # Cutting, dieting

--- a/_posts/2019-09-07-activities-guiding-my-professional-career.md
+++ b/_posts/2019-09-07-activities-guiding-my-professional-career.md
@@ -1,14 +1,15 @@
 ---
 layout: post
-title: "Activities guiding my professional career"
-date: '2019-09-07T00:00:00.001-05:00'
+title: Activities guiding my professional career
+date: 2019-09-07T00:00:00.001-05:00
 author: Douglas Hindson
-tags: 
-- blog
-- career
-- personal development
-- tech industry
-modified_time: '2019-07-07T00:00:00.001-05:00'
+tags:
+  - blog
+  - career
+  - professional
+  - development
+  - d-tier
+modified_time: 2019-07-07T00:00:00.001-05:00
 ---
 
 # Purpose

--- a/_posts/2019-09-07-what-Im-looking-for-in-my-next-job.md
+++ b/_posts/2019-09-07-what-Im-looking-for-in-my-next-job.md
@@ -6,6 +6,7 @@ author: Douglas Hindson
 tags:
   - blog
   - career
+  - d-tier
 modified_time: 2021-09-22T00:00:00.001-05:00
 ---
 

--- a/_posts/2019-09-21-performance-of-a-program-manager.md
+++ b/_posts/2019-09-21-performance-of-a-program-manager.md
@@ -1,12 +1,12 @@
 ---
 layout: post
-title: "On the performance of a program manager"
-date: '2019-09-21T00:00:00.001-05:00'
+title: On the performance of a program manager
+date: 2019-09-21T00:00:00.001-05:00
 author: Douglas Hindson
-tags: 
-- career
-- tech industry
-modified_time: '2019-09-21T00:00:00.001-05:00'
+tags:
+  - career
+  - f-tier
+modified_time: 2019-09-21T00:00:00.001-05:00
 ---
 
 [Bus factor](https://en.wikipedia.org/wiki/Bus_factor) in a company is the risk that information and capabilities are not shared among team members. If a person has a high bus factor, they have a significant amount of information and capabilities that aren't shared among the rest of the team.

--- a/_posts/2019-12-22-lighthouse-gaze.md
+++ b/_posts/2019-12-22-lighthouse-gaze.md
@@ -1,12 +1,13 @@
 ---
 layout: post
-title: "Lighthouse Gaze"
-date: '2019-12-22T00:00:00.001-05:00'
+title: Lighthouse Gaze
+date: 2019-12-22T00:00:00.001-05:00
 author: Douglas Hindson
-tags: 
-- blog
-- story
-modified_time: '2019-12-22T00:00:00.001-05:00'
+tags:
+  - blog
+  - story
+  - d-tier
+modified_time: 2019-12-22T00:00:00.001-05:00
 ---
 
 _Some people look most beautiful in sunlight because their low-contrast features are exposed._

--- a/_posts/2020-01-31-fitness-noob.md
+++ b/_posts/2020-01-31-fitness-noob.md
@@ -1,11 +1,12 @@
 ---
 layout: post
-title: "Hey, fitness noob!"
-date: '2020-01-31T00:00:00.001-05:00'
+title: Hey, fitness noob!
+date: 2020-01-31T00:00:00.001-05:00
 author: Douglas Hindson
-tags: 
-- fitness
-modified_time: '2020-01-31T00:00:00.001-05:00'
+tags:
+  - fitness
+  - d-tier
+modified_time: 2020-01-31T00:00:00.001-05:00
 ---
 
 I grew up playing most sports and eating healthy. Despite that, I made mistakes when I tried to get fit and be more attractive. It's easy to screw up improving your fitness, but it's easy to do well too - you need a breadth of simple knowledge. This is the article I wish I had when I started intentionally improving my fitness.

--- a/_posts/2020-02-15-habits.md
+++ b/_posts/2020-02-15-habits.md
@@ -1,13 +1,15 @@
 ---
 layout: post
-title: "Habits"
-date: '2020-02-15T00:00:00.001-05:00'
+title: Habits
+date: 2020-02-15T00:00:00.001-05:00
 author: Douglas Hindson
-tags: 
-- personal development
-- habit
-- favourite
-modified_time: '2020-02-15T00:00:00.001-05:00'
+tags:
+  - habit
+  - favourite
+  - personal
+  - development
+  - d-tier
+modified_time: 2020-02-15T00:00:00.001-05:00
 ---
 
 I can't trust myself. What I want now doesn't help me achieve my goals in life, but my short-term wants are so, so powerful.

--- a/_posts/2020-02-24-diet.md
+++ b/_posts/2020-02-24-diet.md
@@ -1,13 +1,14 @@
 ---
 layout: post
-title: "My diet"
-date: '2020-02-24T00:00:00.001-05:00'
+title: My diet
+date: 2020-02-24T00:00:00.001-05:00
 author: Douglas Hindson
-tags: 
-- fitness
-- habit
-- favourite
-modified_time: '2020-02-24T00:00:00.001-05:00'
+tags:
+  - fitness
+  - habit
+  - favourite
+  - d-tier
+modified_time: 2020-02-24T00:00:00.001-05:00
 ---
 
 I had an extreme diet and not the average extreme. Over the last few years, I ate the same thing for breakfast and lunch. More than half of my calories came from [one food item](https://queal.com/en/). I obsessed about eating efficiently for more than ten years, optimizing for effort. I took pleasure in the [dogmatic sacrifices](/i-hate-cars-and-chewing-is-redundant/) I had to make: bland food, no variety, missing out on socializing over food... It didn't matter. My time and mental energy were better spent elsewhere. I adored the idea of my diet, and it worked until it didn't - until I became more serious about fitness. I saw [a dietician](https://www.thesportsnutritioncoach.com/) who convinced me that my diet was interfering with my goals.

--- a/_posts/2020-05-25-how-i-speak-product.md
+++ b/_posts/2020-05-25-how-i-speak-product.md
@@ -1,13 +1,15 @@
 ---
 layout: post
-title: "How I speak product"
-date: '2020-05-25T00:00:00.001-05:00'
+title: How I speak product
+date: 2020-05-25T00:00:00.001-05:00
 author: Douglas Hindson
-tags: 
-- personal development
-- professional
-- favourite
-modified_time: '2020-05-25T00:00:00.001-05:00'
+tags:
+  - professional
+  - favourite
+  - personal
+  - development
+  - c-tier
+modified_time: 2020-05-25T00:00:00.001-05:00
 ---
 
 I've observed that people around me are solution-oriented. We like to focus on what needs to be done - the solution. The following interaction happens with everyone, from engineers to salespeople:

--- a/_posts/2020-06-27-passion-career-path.md
+++ b/_posts/2020-06-27-passion-career-path.md
@@ -1,12 +1,14 @@
 ---
 layout: post
-title: "Passion and career path"
-date: '2020-06-27T00:00:00.001-05:00'
+title: Passion and career path
+date: 2020-06-27T00:00:00.001-05:00
 author: Douglas Hindson
 tags:
-- personal development
-- professional
-modified_time: '2020-06-27T00:00:00.001-05:00'
+  - professional
+  - d-tier
+  - personal
+  - development
+modified_time: 2020-06-27T00:00:00.001-05:00
 ---
 
 A university student approached me for advice on their career direction. They asked a question that reminded me of how I felt at that stage in my career. I'm sure this same advice has been given many times before.

--- a/_posts/2020-09-06-plants.md
+++ b/_posts/2020-09-06-plants.md
@@ -1,12 +1,13 @@
 ---
 layout: post
-title: "Plants"
-date: '2020-09-06T00:00:00.001-05:00'
+title: Plants
+date: 2020-09-06T00:00:00.001-05:00
 author: Douglas Hindson
-tags: 
-- projects
-- essays
-modified_time: '2020-09-06T00:00:00.001-05:00'
+tags:
+  - project
+  - essays
+  - d-tier
+modified_time: 2020-09-06T00:00:00.001-05:00
 ---
 
 <img src="/images/141 - STMPWD0.jpg"><br/>

--- a/_posts/2020-11-29-goals.md
+++ b/_posts/2020-11-29-goals.md
@@ -1,12 +1,14 @@
 ---
 layout: post
-title: "Personal Goals"
-date: '2020-11-29T00:00:00.001-05:00'
+title: Personal Goals
+date: 2020-11-29T00:00:00.001-05:00
 author: Douglas Hindson
-tags: 
-- personal development
-- favourite
-modified_time: '2020-11-29T00:00:00.001-05:00'
+tags:
+  - favourite
+  - c-tier
+  - personal
+  - development
+modified_time: 2020-11-29T00:00:00.001-05:00
 ---
 
 I was 25 years old, a few months into a new job and a new city. My career was finally on a good trajectory. But my broader life - was I on the right track? It felt like "no", but I couldn't say why or what to change. That left me anxious.

--- a/_posts/2021-03-28-product-engineer.md
+++ b/_posts/2021-03-28-product-engineer.md
@@ -1,12 +1,14 @@
 ---
 layout: post
-title: "Product Engineer"
-date: '2021-03-28T00:00:00.001-05:00'
+title: Product Engineer
+date: 2021-03-28T00:00:00.001-05:00
 author: Douglas Hindson
-tags: 
-- personal development
-- professional
-modified_time: '2021-03-28T00:00:00.001-05:00'
+tags:
+  - professional
+  - personal
+  - development
+  - d-tier
+modified_time: 2021-03-28T00:00:00.001-05:00
 ---
 
 In a previous job I was onboarding a senior product person. I complained that some important task shouldn't be mine to do. The senior product person said, in effect,

--- a/_posts/2022-02-13-valentines-day.md
+++ b/_posts/2022-02-13-valentines-day.md
@@ -1,11 +1,12 @@
 ---
 layout: post
-title: "Valentine's Day"
-date: '2022-02-13T00:00:00.001-05:00'
+title: Valentine's Day
+date: 2022-02-13T00:00:00.001-05:00
 author: Douglas Hindson
-tags: 
-- essay
-modified_time: '2022-02-13T00:00:00.001-05:00'
+tags:
+  - essay
+  - c-tier
+modified_time: 2022-02-13T00:00:00.001-05:00
 ---
 
 Modern Valentine's Day feels dystopian. Consumerism and romantic love culture have carried it off to Vatican Disneyland. If you don't have a committed relationship, it's a tossup between unexpected butterflies and unpleasant reminders. For the committed, it's celebrating that commitment.

--- a/_posts/2022-07-08-mentor.md
+++ b/_posts/2022-07-08-mentor.md
@@ -1,12 +1,14 @@
 ---
 layout: post
-title: "Mentor, visualized"
-date: '2022-07-08T00:00:00.001-05:00'
+title: Mentor, visualized
+date: 2022-07-08T00:00:00.001-05:00
 author: Douglas Hindson
-tags: 
-- personal development
-- professional
-modified_time: '2022-07-08T00:00:00.001-05:00'
+tags:
+  - professional
+  - personal
+  - development
+  - c-tier
+modified_time: 2022-07-08T00:00:00.001-05:00
 ---
 
 It took me a long time to understand why mentors are useful. I think it’s because I’m a visual person, and no one ever visualised a major aspect of what makes mentors useful.

--- a/_posts/2022-09-04-duke-of-intent.md
+++ b/_posts/2022-09-04-duke-of-intent.md
@@ -5,6 +5,7 @@ date: 2022-09-04T00:00:00.001-05:00
 author: Douglas Hindson
 tags:
   - story
+  - d-tier
 modified_time: 2022-07-08T00:00:00.001-05:00
 ---
 

--- a/_posts/2022-09-11-negative-planning.md
+++ b/_posts/2022-09-11-negative-planning.md
@@ -1,12 +1,14 @@
 ---
 layout: post
-title: "Plan when not to follow a habit"
-date: '2022-09-11T00:00:00.000-00:00'
+title: Plan when not to follow a habit
+date: 2022-09-11T00:00:00.000-00:00
 author: Douglas Hindson
 tags:
-- personal development
-- habits
-modified_time: '2022-09-11T00:00:00.000-00:00'
+  - habits
+  - d-tier
+  - personal
+  - development
+modified_time: 2022-09-11T00:00:00.000-00:00
 ---
 
 Say you have a good habit like, *"I go to the gym regularly."* To set up [habits for success](/habits), plan when you're **not** going to do it. 

--- a/_posts/2023-01-07-after-together.md
+++ b/_posts/2023-01-07-after-together.md
@@ -5,6 +5,7 @@ date: 2023-01-07T00:00:00.001-05:00
 author: Douglas Hindson
 tags:
   - story
+  - c-tier
 modified_time: 2023-01-07T00:00:00.001-05:00
 ---
 

--- a/_posts/2023-12-01-suboptimal-ideal.md
+++ b/_posts/2023-12-01-suboptimal-ideal.md
@@ -5,6 +5,7 @@ date: 2023-11-15T00:00:00.001-05:00
 author: Douglas Hindson
 tags:
   - story
+  - d-tier
 modified_time: 2023-11-15T00:00:00.001-05:00
 ---
 

--- a/_posts/2024-02-16-philosophy-study.md
+++ b/_posts/2024-02-16-philosophy-study.md
@@ -9,6 +9,7 @@ tags:
   - personal
   - development
   - favourite
+  - c-tier
 modified_time: 2024-02-16T16:50:47.073-05:00
 ---
 I'm taking a year to study philosophy and write a book. I plan on returning to industry after.

--- a/_posts/2024-05-19-perfect-mara.md
+++ b/_posts/2024-05-19-perfect-mara.md
@@ -5,6 +5,7 @@ date: 2024-05-19T00:00:00.001-05:00
 author: Douglas Hindson
 tags:
   - story
+  - f-tier
 modified_time: 2023-05-19T00:00:00.001-05:00
 ---
 

--- a/_posts/2024-07-01-parable-on-the-vulnerable.md
+++ b/_posts/2024-07-01-parable-on-the-vulnerable.md
@@ -9,6 +9,7 @@ tags:
   - essay
   - favourite
   - feminism
+  - c-tier
 modified_time: 2019-07-01T00:00:00.001-05:00
 ---
 Here is an excerpt from [a post](/one-day-of-travel) I wrote ten years ago, describing my travel between two cities in Indonesia:

--- a/_posts/2024-07-06-artists.md
+++ b/_posts/2024-07-06-artists.md
@@ -5,6 +5,7 @@ date: 2024-07-06T00:00:00.001-05:00
 author: Douglas Hindson
 tags:
   - essay
+  - f-tier
 modified_time: 2024-07-06T00:00:00.001-05:00
 ---
 

--- a/_posts/2024-07-08-our-venerable-tools.md
+++ b/_posts/2024-07-08-our-venerable-tools.md
@@ -5,6 +5,7 @@ date: 2024-07-08T00:00:00.001-05:00
 author: Douglas Hindson
 tags:
   - essay
+  - f-tier
 modified_time: 2024-07-08T00:00:00.001-05:00
 ---
 If you take a big knife out anywhere in first-world culture, people will be like, "what are you doing with that big knife?" And you might even get arrested just for carrying it around.

--- a/_posts/2024-07-16-when-in-the-chronicle-of-wasted-time.md
+++ b/_posts/2024-07-16-when-in-the-chronicle-of-wasted-time.md
@@ -5,6 +5,7 @@ date: 2024-07-16T00:00:00.001-05:00
 author: Douglas Hindson
 tags:
   - story
+  - c-tier
 modified_time: 2024-07-16T00:00:00.001-05:00
 ---
 > When in the chronicle of wasted time,

--- a/_posts/2024-07-20-microsoft-google-and-strawberry-liquorice.md
+++ b/_posts/2024-07-20-microsoft-google-and-strawberry-liquorice.md
@@ -6,6 +6,7 @@ author: Douglas Hindson
 tags:
   - personal
   - development
+  - b-tier
 modified_time: 2024-07-20T00:00:00.001-05:00
 ---
 These days I'm at the family cottage, studying Kant and writing. My dad comes up on the weekends and this Friday after dinner, my dad, his partner, and I were sitting around the table, playing cards and eating candy. Conversation drifted to figuring out what flavours were in the candy.

--- a/_posts/2024-07-22-unleash-your-inner-lily.md
+++ b/_posts/2024-07-22-unleash-your-inner-lily.md
@@ -6,6 +6,7 @@ author: Douglas Hindson
 tags:
   - story
   - feminism
+  - c-tier
 modified_time: 2024-07-22T00:00:00.001-05:00
 ---
 Lily is a little beagle who must not have freedom, it's for her own good. At all times, she must be leashed or incarcerated because she will always find a way to abuse her freedom.

--- a/_posts/2024-08-30-recreation-of-adam.md
+++ b/_posts/2024-08-30-recreation-of-adam.md
@@ -5,6 +5,7 @@ date: 2024-08-30T00:00:00.001-05:00
 author: Douglas Hindson
 tags:
   - story
+  - a-tier
 modified_time: 2024-08-30T00:00:00.001-05:00
 ---
 1. **The story** (10min read)

--- a/_posts/2024-09-01-editing-science-fiction-with-llms.md
+++ b/_posts/2024-09-01-editing-science-fiction-with-llms.md
@@ -4,8 +4,9 @@ title: Writers will dominate in a world of LLMs (part 1)
 date: 2024-09-01T00:00:00.001-05:00
 author: Douglas Hindson
 tags:
-  - projects
+  - project
   - story
+  - c-tier
 modified_time: 2024-09-01T00:00:00.001-05:00
 ---
 I find writing to be a lot like building. It's the most human form of building, where you get to choose how much reality to include in your work. The culture of writing is as old as civilization but it's still developing, while the culture of building IT products is new and innovating. These two cultures can learn a lot from each other.

--- a/_posts/2024-09-13-recognition-vs-recollection.md
+++ b/_posts/2024-09-13-recognition-vs-recollection.md
@@ -8,6 +8,7 @@ tags:
   - professional
   - development
   - favourite
+  - b-tier
 modified_time: 2024-09-13T00:00:00.001-05:00
 ---
 Memorizing is a waste of time. Find a way to learn without memorizing.

--- a/_posts/2024-09-14-preventative-sadness.md
+++ b/_posts/2024-09-14-preventative-sadness.md
@@ -6,6 +6,7 @@ author: Douglas Hindson
 tags:
   - story
   - poetry
+  - c-tier
 modified_time: 2024-09-14T00:00:00.001-05:00
 ---
 > I once was a man who was often sad,<br>

--- a/_posts/2024-11-01-automating-art-craft.md
+++ b/_posts/2024-11-01-automating-art-craft.md
@@ -4,9 +4,10 @@ title: Automating art-craft
 date: 2024-11-02T00:00:00.001-05:00
 author: Douglas Hindson
 tags:
-  - projects
+  - project
   - essay
   - essays
+  - c-tier
 modified_time: 2024-11-02T00:00:00.001-05:00
 ---
 > Be the data you want to see in the world.

--- a/_posts/2024-12-03-eagle-and-beavers.md
+++ b/_posts/2024-12-03-eagle-and-beavers.md
@@ -7,6 +7,7 @@ tags:
   - story
   - personal
   - development
+  - d-tier
 modified_time: 2024-12-04T00:00:00.001-05:00
 ---
 There once was an eagle who commissioned an army of beavers to build a great dam to divert a river. They started in the summer, and the beavers built busily underwater. When fall came around and the dam was not yet built, the eagle assembled the beavers and explained,

--- a/_posts/2024-12-23-masters-and-slaves-of-the-universe.md
+++ b/_posts/2024-12-23-masters-and-slaves-of-the-universe.md
@@ -5,6 +5,7 @@ date: 2024-12-23T00:00:00.001-05:00
 author: Douglas Hindson
 tags:
   - essay
+  - f-tier
 modified_time: 2024-12-23T00:00:00.001-05:00
 ---
 ## The argument: are we masters or slaves of the universe?

--- a/_posts/2025-05-10-beyond-better-and-worse.md
+++ b/_posts/2025-05-10-beyond-better-and-worse.md
@@ -5,6 +5,7 @@ date: 2025-05-10T00:00:00.001-05:00
 author: Douglas Hindson
 tags:
   - essay
+  - d-tier
 modified_time: 2025-05-10T00:00:00.001-05:00
 ---
 ## Part 1: Good and evil

--- a/_posts/2025-07-30-product-managers.md
+++ b/_posts/2025-07-30-product-managers.md
@@ -7,6 +7,7 @@ tags:
   - personal
   - development
   - professional
+  - d-tier
 modified_time: 2025-07-30T00:00:00.001-05:00
 ---
 I've never seen a good product manager in an AI company.

--- a/_posts/2025-10-11-An-AI-writing-process.md
+++ b/_posts/2025-10-11-An-AI-writing-process.md
@@ -5,7 +5,8 @@ date: 2025-10-11T00:00:00.001-05:00
 author: Douglas Hindson
 tags:
   - professional
-  - projects
+  - project
+  - d-tier
 modified_time: 2025-07-30T00:00:00.001-05:00
 ---
 ## forwards

--- a/_posts/2026-03-29-squirrel-and-deer.md
+++ b/_posts/2026-03-29-squirrel-and-deer.md
@@ -7,6 +7,7 @@ tags:
   - story
   - personal
   - development
+  - c-tier
 modified_time: 2024-12-04T00:00:00.001-05:00
 ---
 A squirrel explained to a deer,

--- a/_posts/2026-04-25-love-extensions.md
+++ b/_posts/2026-04-25-love-extensions.md
@@ -5,6 +5,7 @@ date: 2026-04-25T00:00:00.001-05:00
 author: Douglas Hindson
 tags:
   - essay
+  - d-tier
 modified_time: 2024-12-04T00:00:00.001-05:00
 ---
 > You can only extend your love to so many things.
@@ -22,7 +23,7 @@ modified_time: 2024-12-04T00:00:00.001-05:00
 > But as "human" begins to change,
 > we no longer agree what it is.
 > 
-> Will you fight to keep it alive-
+> Who will fight to keep it alive-
 > 
-> or learn to die,
+> and who will learn to die,
 > and love beyond it?

--- a/css/main.css
+++ b/css/main.css
@@ -43,13 +43,14 @@ a:hover {
 
 .site-masthead {
   margin-bottom: 2.5rem;
+  text-align: center;
 }
 
 .site-name {
   font-family: var(--sans);
-  font-size: 1.5rem;
+  font-size: 2.2rem;
   font-weight: 700;
-  letter-spacing: -0.01em;
+  letter-spacing: -0.02em;
   color: var(--text);
   text-decoration: none;
   display: block;
@@ -434,58 +435,250 @@ button:active {
   box-shadow: inset 0 2px 3px rgba(0, 0, 0, 0.15);
 }
 
-/* ===== CATEGORY TABS ===== */
+/* ===== VIEW PICKER ===== */
 
-.cat-tabs {
+.homepage-header {
+  position: relative;
   display: flex;
-  flex-wrap: wrap;
-  gap: 0.4rem;
-  margin-bottom: 1.75rem;
+  align-items: center;
+  margin-bottom: 0.75rem;
+  padding-left: 1rem;
 }
 
-.cat-tab {
+.view-picker {
+  position: relative;
+  display: inline-block;
+}
+
+.view-pick-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
   font-family: var(--sans);
-  font-size: 0.68rem;
-  font-weight: 600;
-  letter-spacing: 0.1em;
-  text-transform: uppercase;
+  font-size: 1.05rem;
+  font-weight: 700;
+  color: var(--text);
   background: none;
-  color: var(--meta);
-  border: 1px solid var(--rule);
-  border-radius: 2px;
-  padding: 0.25rem 0.65rem;
+  border: none;
+  padding: 0;
   cursor: pointer;
-  text-decoration: none;
-  line-height: 1.6;
   -webkit-appearance: none;
-  transition: none;
 }
 
-.cat-tab:hover {
+.view-pick-btn:hover {
   color: var(--text);
-  border-color: #bbb;
   opacity: 1;
 }
 
-.cat-tab:active {
-  box-shadow: none;
+.view-pick-btn svg {
+  flex-shrink: 0;
+  opacity: 0.4;
+  transition: transform 0.15s;
 }
 
-.cat-tab.active {
-  background: var(--text);
-  color: var(--bg);
-  border-color: var(--text);
+.view-picker.open .view-pick-btn svg {
+  transform: rotate(180deg);
 }
 
-.cat-section-label {
+.view-dropdown {
+  display: none;
+  position: absolute;
+  top: calc(100% + 4px);
+  left: 50%;
+  transform: translateX(-50%);
+  background: var(--bg);
+  border: 1px solid #ccc;
+  border-radius: 2px;
+  z-index: 20;
+  min-width: 9rem;
+  box-shadow: 0 3px 10px rgba(0,0,0,0.1);
+  padding: 0.25rem 0;
+}
+
+.view-picker.open .view-dropdown {
+  display: block;
+}
+
+.view-option {
+  display: block;
+  width: 100%;
+  text-align: left;
   font-family: var(--sans);
-  font-size: 0.62rem;
+  font-size: 0.78rem;
+  font-weight: 500;
+  color: var(--soft);
+  background: none;
+  border: none;
+  border-radius: 0;
+  padding: 0.35rem 0.9rem;
+  cursor: pointer;
+  -webkit-appearance: none;
+  line-height: 1.6;
+}
+
+.view-option:hover {
+  color: var(--text);
+  background: var(--rule);
+}
+
+.view-option.active {
+  color: var(--text);
   font-weight: 700;
-  letter-spacing: 0.22em;
+}
+
+/* ===== CATEGORY PICKER ===== */
+
+.cat-picker {
+  position: relative;
+  margin-left: auto;
+  z-index: 10;
+}
+
+.cat-pick-btn {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0.65rem 0.75rem;
+  color: var(--meta);
+  background: none;
+  border: none;
+  border-radius: 0;
+  cursor: pointer;
+  -webkit-appearance: none;
+  line-height: 1;
+}
+
+.cat-pick-btn:hover,
+.cat-picker.open .cat-pick-btn {
+  color: var(--text);
+}
+
+.cat-pick-btn svg {
+  width: 12px;
+  height: 10px;
+}
+
+.cat-dropdown {
+  display: none;
+  position: absolute;
+  top: calc(100% + 3px);
+  right: 0;
+  left: auto;
+  background: var(--bg);
+  border: 1px solid #ccc;
+  border-radius: 2px;
+  z-index: 20;
+  min-width: 9rem;
+  box-shadow: 0 3px 10px rgba(0,0,0,0.1);
+  padding: 0.25rem 0;
+}
+
+.cat-picker.open .cat-dropdown {
+  display: block;
+}
+
+.cat-option {
+  display: block;
+  width: 100%;
+  text-align: left;
+  font-family: var(--sans);
+  font-size: 0.68rem;
+  font-weight: 600;
+  letter-spacing: 0.08em;
   text-transform: uppercase;
   color: var(--meta);
-  margin-bottom: 0.75rem;
-  margin-top: 0.25rem;
+  background: none;
+  border: none;
+  border-radius: 0;
+  padding: 0.35rem 0.9rem;
+  cursor: pointer;
+  -webkit-appearance: none;
+  line-height: 1.6;
+}
+
+.cat-option:hover {
+  color: var(--text);
+  background: var(--rule);
+}
+
+.cat-option.active {
+  color: var(--text);
+  font-weight: 700;
+}
+
+/* ===== TIER ROWS ===== */
+
+.tier-row {
+  display: flex;
+  align-items: stretch;
+  border: 1px solid var(--rule);
+  margin-left: -1.5rem;
+  margin-bottom: 0.4rem;
+  border-radius: 2px;
+  overflow: hidden;
+}
+
+.tier-key {
+  font-family: var(--sans);
+  font-size: 1rem;
+  font-weight: 800;
+  width: 1.5rem;
+  min-width: 1.5rem;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border-right: 2px solid rgba(0,0,0,0.08);
+  color: rgba(0,0,0,0.55);
+  flex-shrink: 0;
+  letter-spacing: -0.02em;
+}
+
+[data-tier="s-tier"] .tier-key { background: #e8aaaa; }
+[data-tier="a-tier"] .tier-key { background: #f0c49a; }
+[data-tier="b-tier"] .tier-key { background: #f0ed9a; }
+[data-tier="c-tier"] .tier-key { background: #a8dda8; }
+[data-tier="d-tier"] .tier-key { background: #a8cfe0; }
+[data-tier="f-tier"] .tier-key { background: #e0a8a8; }
+[data-tier="notes"]  .tier-key { background: #d8d4cc; color: rgba(0,0,0,0.35); font-size: 1.2rem; }
+
+ul.posts.tier-posts {
+  flex: 1;
+  margin: 0;
+  padding: 0.55rem 0.75rem;
+}
+
+ul.posts.tier-posts li {
+  margin-bottom: 0.35rem;
+}
+
+ul.posts.tier-posts li:last-child {
+  margin-bottom: 0;
+}
+
+ul.posts.tier-posts li a,
+#view-bydate ul.posts li a {
+  flex: 1;
+  min-width: 0;
+}
+
+.cat-badge {
+  font-size: 0.72rem;
+  flex-shrink: 0;
+  align-self: center;
+  padding: 0 0.2rem;
+  white-space: nowrap;
+  color: var(--meta);
+  background: none;
+}
+
+.cat-badge.story   { font-family: var(--serif); font-style: italic; }
+.cat-badge.essay   { font-family: var(--serif); font-variant: small-caps; letter-spacing: 0.04em; }
+.cat-badge.grow    { font-family: var(--sans); font-weight: 700; font-size: 0.62rem; letter-spacing: 0.08em; text-transform: uppercase; }
+.cat-badge.fitness { font-family: var(--sans); font-style: italic; font-size: 0.65rem; }
+.cat-badge.project { font-family: var(--mono); font-size: 0.62rem; }
+
+#view-bydate .cat-section > .year-group:first-child .year-label {
+  padding-right: 2.5rem;
 }
 
 /* ===== HOMEPAGE COMPATIBILITY ===== */

--- a/index.html
+++ b/index.html
@@ -3,122 +3,395 @@ layout: default
 title: curiousest
 ---
 
-<section id="best">
-  <div class="section-label">Posts that define me</div>
-  <ul class="posts">
-    {% for post in site.posts %}
-      {% if post.tags contains "favourite" %}
-        <li><a href="{{ post.url }}" title="{{ post.title }}">{{ post.title }}</a></li>
-      {% endif %}
-    {% endfor %}
-  </ul>
-</section>
+<div class="homepage-header">
+  <div class="view-picker" id="view-picker">
+    <button class="view-pick-btn" id="view-pick-btn" aria-haspopup="listbox" aria-expanded="false">
+      <span id="view-pick-label">Tier list of my posts</span>
+      <svg width="8" height="5" viewBox="0 0 8 5" fill="currentColor" aria-hidden="true"><path d="M0 0l4 5 4-5z"/></svg>
+    </button>
+    <div class="view-dropdown" id="view-dropdown" role="listbox">
+      <button class="view-option active" data-view="tierlist" data-label="Tier list of my posts">Tier list</button>
+      <button class="view-option" data-view="bydate" data-label="Posts by date">By date</button>
+    </div>
+  </div>
+  <div class="cat-picker" id="cat-picker">
+    <button class="cat-pick-btn" id="cat-pick-btn" aria-label="Filter by category" aria-haspopup="listbox" aria-expanded="false">
+      <svg width="15" height="12" viewBox="0 0 15 12" fill="currentColor" aria-hidden="true">
+        <rect x="0" y="0" width="15" height="2" rx="1"/>
+        <rect x="3" y="5" width="9" height="2" rx="1"/>
+        <rect x="6" y="10" width="3" height="2" rx="1"/>
+      </svg>
+    </button>
+    <div class="cat-dropdown" role="listbox">
+      <button class="cat-option active" data-cat="all">All</button>
+      <button class="cat-option" data-cat="stories">Stories</button>
+      <button class="cat-option" data-cat="grow">Grow</button>
+      <button class="cat-option" data-cat="essays">Essays</button>
+      <button class="cat-option" data-cat="fitness">Fitness</button>
+      <button class="cat-option" data-cat="projects">Project</button>
+    </div>
+  </div>
+</div>
 
 <section id="categories">
-  <div class="cat-tabs">
-    <button class="cat-tab" data-cat="grow">Grow</button>
-    <button class="cat-tab active" data-cat="stories">Stories</button>
-    <button class="cat-tab" data-cat="essays">Essays</button>
-    <button class="cat-tab" data-cat="fitness">Fitness</button>
-    <button class="cat-tab" data-cat="projects">Projects</button>
-  </div>
+  {% assign tiers = "s-tier,a-tier,b-tier,c-tier,d-tier,f-tier,notes" | split: "," %}
 
-  <div class="cat-section" data-cat="grow">
-    <div class="cat-section-label">Grow</div>
-    <ul class="posts">
-      {% for post in site.posts %}
-        {% if post.tags contains "development" or post.tags contains "personal development" %}
-          <li><a href="{{ post.url }}" title="{{ post.title }}">{{ post.title }}</a></li>
+  <!-- ===== TIER LIST VIEW ===== -->
+  <div id="view-tierlist">
+
+    <div class="cat-section" data-cat="all">
+      {% for tier in tiers %}
+        {% assign tier_posts = "" | split: "" %}
+        {% for post in site.posts %}
+          {% if post.tags contains tier %}
+            {% assign tier_posts = tier_posts | push: post %}
+          {% endif %}
+        {% endfor %}
+        {% if tier_posts.size > 0 or tier == "s-tier" %}
+          <div class="tier-row" data-tier="{{ tier }}">
+            <div class="tier-key">{% if tier == "notes" %}∅{% else %}{{ tier | slice: 0 | upcase }}{% endif %}</div>
+            <ul class="posts tier-posts">
+              {% for post in tier_posts %}
+                <li><a href="{{ post.url }}" title="{{ post.title }}">{{ post.title }}</a>{% if post.tags contains "story" %}<span class="cat-badge story">story</span>{% elsif post.tags contains "development" or post.tags contains "personal development" %}<span class="cat-badge grow">grow</span>{% elsif post.tags contains "essay" %}<span class="cat-badge essay">essay</span>{% elsif post.tags contains "fitness" %}<span class="cat-badge fitness">fitness</span>{% elsif post.tags contains "project" or post.tags contains "facts and data" %}<span class="cat-badge project">project</span>{% endif %}</li>
+              {% endfor %}
+            </ul>
+          </div>
         {% endif %}
       {% endfor %}
-    </ul>
-  </div>
+    </div>
 
-  <div class="cat-section" data-cat="stories">
-    <div class="cat-section-label">Stories</div>
-    <ul class="posts">
+    <div class="cat-section" data-cat="stories" style="display:none">
+      {% for tier in tiers %}
+        {% assign tier_posts = "" | split: "" %}
+        {% for post in site.posts %}
+          {% if post.tags contains tier and post.tags contains "story" %}
+            {% assign tier_posts = tier_posts | push: post %}
+          {% endif %}
+        {% endfor %}
+        {% if tier_posts.size > 0 or tier == "s-tier" %}
+          <div class="tier-row" data-tier="{{ tier }}">
+            <div class="tier-key">{% if tier == "notes" %}∅{% else %}{{ tier | slice: 0 | upcase }}{% endif %}</div>
+            <ul class="posts tier-posts">
+              {% for post in tier_posts %}
+                <li><a href="{{ post.url }}" title="{{ post.title }}">{{ post.title }}</a>{% if post.tags contains "story" %}<span class="cat-badge story">story</span>{% elsif post.tags contains "development" or post.tags contains "personal development" %}<span class="cat-badge grow">grow</span>{% elsif post.tags contains "essay" %}<span class="cat-badge essay">essay</span>{% elsif post.tags contains "fitness" %}<span class="cat-badge fitness">fitness</span>{% elsif post.tags contains "project" or post.tags contains "facts and data" %}<span class="cat-badge project">project</span>{% endif %}</li>
+              {% endfor %}
+            </ul>
+          </div>
+        {% endif %}
+      {% endfor %}
+    </div>
+
+    <div class="cat-section" data-cat="grow" style="display:none">
+      {% for tier in tiers %}
+        {% assign tier_posts = "" | split: "" %}
+        {% for post in site.posts %}
+          {% if post.tags contains tier and post.tags contains "development" or post.tags contains tier and post.tags contains "personal development" %}
+            {% assign tier_posts = tier_posts | push: post %}
+          {% endif %}
+        {% endfor %}
+        {% if tier_posts.size > 0 or tier == "s-tier" %}
+          <div class="tier-row" data-tier="{{ tier }}">
+            <div class="tier-key">{% if tier == "notes" %}∅{% else %}{{ tier | slice: 0 | upcase }}{% endif %}</div>
+            <ul class="posts tier-posts">
+              {% for post in tier_posts %}
+                <li><a href="{{ post.url }}" title="{{ post.title }}">{{ post.title }}</a>{% if post.tags contains "story" %}<span class="cat-badge story">story</span>{% elsif post.tags contains "development" or post.tags contains "personal development" %}<span class="cat-badge grow">grow</span>{% elsif post.tags contains "essay" %}<span class="cat-badge essay">essay</span>{% elsif post.tags contains "fitness" %}<span class="cat-badge fitness">fitness</span>{% elsif post.tags contains "project" or post.tags contains "facts and data" %}<span class="cat-badge project">project</span>{% endif %}</li>
+              {% endfor %}
+            </ul>
+          </div>
+        {% endif %}
+      {% endfor %}
+    </div>
+
+    <div class="cat-section" data-cat="essays" style="display:none">
+      {% for tier in tiers %}
+        {% assign tier_posts = "" | split: "" %}
+        {% for post in site.posts %}
+          {% if post.tags contains tier and post.tags contains "essay" %}
+            {% assign tier_posts = tier_posts | push: post %}
+          {% endif %}
+        {% endfor %}
+        {% if tier_posts.size > 0 or tier == "s-tier" %}
+          <div class="tier-row" data-tier="{{ tier }}">
+            <div class="tier-key">{% if tier == "notes" %}∅{% else %}{{ tier | slice: 0 | upcase }}{% endif %}</div>
+            <ul class="posts tier-posts">
+              {% for post in tier_posts %}
+                <li><a href="{{ post.url }}" title="{{ post.title }}">{{ post.title }}</a>{% if post.tags contains "story" %}<span class="cat-badge story">story</span>{% elsif post.tags contains "development" or post.tags contains "personal development" %}<span class="cat-badge grow">grow</span>{% elsif post.tags contains "essay" %}<span class="cat-badge essay">essay</span>{% elsif post.tags contains "fitness" %}<span class="cat-badge fitness">fitness</span>{% elsif post.tags contains "project" or post.tags contains "facts and data" %}<span class="cat-badge project">project</span>{% endif %}</li>
+              {% endfor %}
+            </ul>
+          </div>
+        {% endif %}
+      {% endfor %}
+    </div>
+
+    <div class="cat-section" data-cat="fitness" style="display:none">
+      {% for tier in tiers %}
+        {% assign tier_posts = "" | split: "" %}
+        {% for post in site.posts %}
+          {% if post.tags contains tier and post.tags contains "fitness" %}
+            {% assign tier_posts = tier_posts | push: post %}
+          {% endif %}
+        {% endfor %}
+        {% if tier_posts.size > 0 or tier == "s-tier" %}
+          <div class="tier-row" data-tier="{{ tier }}">
+            <div class="tier-key">{% if tier == "notes" %}∅{% else %}{{ tier | slice: 0 | upcase }}{% endif %}</div>
+            <ul class="posts tier-posts">
+              {% for post in tier_posts %}
+                <li><a href="{{ post.url }}" title="{{ post.title }}">{{ post.title }}</a>{% if post.tags contains "story" %}<span class="cat-badge story">story</span>{% elsif post.tags contains "development" or post.tags contains "personal development" %}<span class="cat-badge grow">grow</span>{% elsif post.tags contains "essay" %}<span class="cat-badge essay">essay</span>{% elsif post.tags contains "fitness" %}<span class="cat-badge fitness">fitness</span>{% elsif post.tags contains "project" or post.tags contains "facts and data" %}<span class="cat-badge project">project</span>{% endif %}</li>
+              {% endfor %}
+            </ul>
+          </div>
+        {% endif %}
+      {% endfor %}
+    </div>
+
+    <div class="cat-section" data-cat="projects" style="display:none">
+      {% for tier in tiers %}
+        {% assign tier_posts = "" | split: "" %}
+        {% for post in site.posts %}
+          {% if post.tags contains tier and post.tags contains "project" or post.tags contains tier and post.tags contains "facts and data" %}
+            {% assign tier_posts = tier_posts | push: post %}
+          {% endif %}
+        {% endfor %}
+        {% if tier_posts.size > 0 or tier == "s-tier" %}
+          <div class="tier-row" data-tier="{{ tier }}">
+            <div class="tier-key">{% if tier == "notes" %}∅{% else %}{{ tier | slice: 0 | upcase }}{% endif %}</div>
+            <ul class="posts tier-posts">
+              {% for post in tier_posts %}
+                <li><a href="{{ post.url }}" title="{{ post.title }}">{{ post.title }}</a>{% if post.tags contains "story" %}<span class="cat-badge story">story</span>{% elsif post.tags contains "development" or post.tags contains "personal development" %}<span class="cat-badge grow">grow</span>{% elsif post.tags contains "essay" %}<span class="cat-badge essay">essay</span>{% elsif post.tags contains "fitness" %}<span class="cat-badge fitness">fitness</span>{% elsif post.tags contains "project" or post.tags contains "facts and data" %}<span class="cat-badge project">project</span>{% endif %}</li>
+              {% endfor %}
+            </ul>
+          </div>
+        {% endif %}
+      {% endfor %}
+    </div>
+
+  </div><!-- #view-tierlist -->
+
+  <!-- ===== BY DATE VIEW ===== -->
+  <div id="view-bydate" style="display:none">
+
+    <div class="cat-section" data-cat="all">
+      {% assign posts_by_year = site.posts | group_by_exp: "post", "post.date | date: '%Y'" %}
+      {% for year_group in posts_by_year %}
+        <div class="year-group">
+          <div class="year-label">{{ year_group.name }}</div>
+          <ul class="posts">
+            {% for post in year_group.items %}
+              <li>
+                <span class="post-date">{{ post.date | date: "%-d %b" }}</span>
+                <a href="{{ post.url }}" title="{{ post.title }}">{{ post.title }}</a>{% if post.tags contains "story" %}<span class="cat-badge story">story</span>{% elsif post.tags contains "development" or post.tags contains "personal development" %}<span class="cat-badge grow">grow</span>{% elsif post.tags contains "essay" %}<span class="cat-badge essay">essay</span>{% elsif post.tags contains "fitness" %}<span class="cat-badge fitness">fitness</span>{% elsif post.tags contains "project" or post.tags contains "facts and data" %}<span class="cat-badge project">project</span>{% endif %}
+              </li>
+            {% endfor %}
+          </ul>
+        </div>
+      {% endfor %}
+    </div>
+
+    <div class="cat-section" data-cat="stories" style="display:none">
+      {% assign bd_posts = "" | split: "" %}
       {% for post in site.posts %}
         {% if post.tags contains "story" %}
-          <li><a href="{{ post.url }}" title="{{ post.title }}">{{ post.title }}</a></li>
+          {% assign bd_posts = bd_posts | push: post %}
         {% endif %}
       {% endfor %}
-    </ul>
-  </div>
+      {% assign posts_by_year = bd_posts | group_by_exp: "post", "post.date | date: '%Y'" %}
+      {% for year_group in posts_by_year %}
+        {% if year_group.items.size > 0 %}
+          <div class="year-group">
+            <div class="year-label">{{ year_group.name }}</div>
+            <ul class="posts">
+              {% for post in year_group.items %}
+                <li>
+                  <span class="post-date">{{ post.date | date: "%-d %b" }}</span>
+                  <a href="{{ post.url }}" title="{{ post.title }}">{{ post.title }}</a>{% if post.tags contains "story" %}<span class="cat-badge story">story</span>{% elsif post.tags contains "development" or post.tags contains "personal development" %}<span class="cat-badge grow">grow</span>{% elsif post.tags contains "essay" %}<span class="cat-badge essay">essay</span>{% elsif post.tags contains "fitness" %}<span class="cat-badge fitness">fitness</span>{% elsif post.tags contains "project" or post.tags contains "facts and data" %}<span class="cat-badge project">project</span>{% endif %}
+                </li>
+              {% endfor %}
+            </ul>
+          </div>
+        {% endif %}
+      {% endfor %}
+    </div>
 
-  <div class="cat-section" data-cat="essays">
-    <div class="cat-section-label">Essays</div>
-    <ul class="posts">
+    <div class="cat-section" data-cat="grow" style="display:none">
+      {% assign bd_posts = "" | split: "" %}
+      {% for post in site.posts %}
+        {% if post.tags contains "development" or post.tags contains "personal development" %}
+          {% assign bd_posts = bd_posts | push: post %}
+        {% endif %}
+      {% endfor %}
+      {% assign posts_by_year = bd_posts | group_by_exp: "post", "post.date | date: '%Y'" %}
+      {% for year_group in posts_by_year %}
+        {% if year_group.items.size > 0 %}
+          <div class="year-group">
+            <div class="year-label">{{ year_group.name }}</div>
+            <ul class="posts">
+              {% for post in year_group.items %}
+                <li>
+                  <span class="post-date">{{ post.date | date: "%-d %b" }}</span>
+                  <a href="{{ post.url }}" title="{{ post.title }}">{{ post.title }}</a>{% if post.tags contains "story" %}<span class="cat-badge story">story</span>{% elsif post.tags contains "development" or post.tags contains "personal development" %}<span class="cat-badge grow">grow</span>{% elsif post.tags contains "essay" %}<span class="cat-badge essay">essay</span>{% elsif post.tags contains "fitness" %}<span class="cat-badge fitness">fitness</span>{% elsif post.tags contains "project" or post.tags contains "facts and data" %}<span class="cat-badge project">project</span>{% endif %}
+                </li>
+              {% endfor %}
+            </ul>
+          </div>
+        {% endif %}
+      {% endfor %}
+    </div>
+
+    <div class="cat-section" data-cat="essays" style="display:none">
+      {% assign bd_posts = "" | split: "" %}
       {% for post in site.posts %}
         {% if post.tags contains "essay" %}
-          <li><a href="{{ post.url }}" title="{{ post.title }}">{{ post.title }}</a></li>
+          {% assign bd_posts = bd_posts | push: post %}
         {% endif %}
       {% endfor %}
-    </ul>
-  </div>
+      {% assign posts_by_year = bd_posts | group_by_exp: "post", "post.date | date: '%Y'" %}
+      {% for year_group in posts_by_year %}
+        {% if year_group.items.size > 0 %}
+          <div class="year-group">
+            <div class="year-label">{{ year_group.name }}</div>
+            <ul class="posts">
+              {% for post in year_group.items %}
+                <li>
+                  <span class="post-date">{{ post.date | date: "%-d %b" }}</span>
+                  <a href="{{ post.url }}" title="{{ post.title }}">{{ post.title }}</a>{% if post.tags contains "story" %}<span class="cat-badge story">story</span>{% elsif post.tags contains "development" or post.tags contains "personal development" %}<span class="cat-badge grow">grow</span>{% elsif post.tags contains "essay" %}<span class="cat-badge essay">essay</span>{% elsif post.tags contains "fitness" %}<span class="cat-badge fitness">fitness</span>{% elsif post.tags contains "project" or post.tags contains "facts and data" %}<span class="cat-badge project">project</span>{% endif %}
+                </li>
+              {% endfor %}
+            </ul>
+          </div>
+        {% endif %}
+      {% endfor %}
+    </div>
 
-  <div class="cat-section" data-cat="fitness">
-    <div class="cat-section-label">Fitness</div>
-    <ul class="posts">
+    <div class="cat-section" data-cat="fitness" style="display:none">
+      {% assign bd_posts = "" | split: "" %}
       {% for post in site.posts %}
         {% if post.tags contains "fitness" %}
-          <li><a href="{{ post.url }}" title="{{ post.title }}">{{ post.title }}</a></li>
+          {% assign bd_posts = bd_posts | push: post %}
         {% endif %}
       {% endfor %}
-    </ul>
-  </div>
+      {% assign posts_by_year = bd_posts | group_by_exp: "post", "post.date | date: '%Y'" %}
+      {% for year_group in posts_by_year %}
+        {% if year_group.items.size > 0 %}
+          <div class="year-group">
+            <div class="year-label">{{ year_group.name }}</div>
+            <ul class="posts">
+              {% for post in year_group.items %}
+                <li>
+                  <span class="post-date">{{ post.date | date: "%-d %b" }}</span>
+                  <a href="{{ post.url }}" title="{{ post.title }}">{{ post.title }}</a>{% if post.tags contains "story" %}<span class="cat-badge story">story</span>{% elsif post.tags contains "development" or post.tags contains "personal development" %}<span class="cat-badge grow">grow</span>{% elsif post.tags contains "essay" %}<span class="cat-badge essay">essay</span>{% elsif post.tags contains "fitness" %}<span class="cat-badge fitness">fitness</span>{% elsif post.tags contains "project" or post.tags contains "facts and data" %}<span class="cat-badge project">project</span>{% endif %}
+                </li>
+              {% endfor %}
+            </ul>
+          </div>
+        {% endif %}
+      {% endfor %}
+    </div>
 
-  <div class="cat-section" data-cat="projects">
-    <div class="cat-section-label">Projects</div>
-    <ul class="posts">
+    <div class="cat-section" data-cat="projects" style="display:none">
+      {% assign bd_posts = "" | split: "" %}
       {% for post in site.posts %}
-        {% if post.tags contains "projects" or post.tags contains "facts and data" %}
-          <li><a href="{{ post.url }}" title="{{ post.title }}">{{ post.title }}</a></li>
+        {% if post.tags contains "project" or post.tags contains "facts and data" %}
+          {% assign bd_posts = bd_posts | push: post %}
         {% endif %}
       {% endfor %}
-    </ul>
-  </div>
+      {% assign posts_by_year = bd_posts | group_by_exp: "post", "post.date | date: '%Y'" %}
+      {% for year_group in posts_by_year %}
+        {% if year_group.items.size > 0 %}
+          <div class="year-group">
+            <div class="year-label">{{ year_group.name }}</div>
+            <ul class="posts">
+              {% for post in year_group.items %}
+                <li>
+                  <span class="post-date">{{ post.date | date: "%-d %b" }}</span>
+                  <a href="{{ post.url }}" title="{{ post.title }}">{{ post.title }}</a>{% if post.tags contains "story" %}<span class="cat-badge story">story</span>{% elsif post.tags contains "development" or post.tags contains "personal development" %}<span class="cat-badge grow">grow</span>{% elsif post.tags contains "essay" %}<span class="cat-badge essay">essay</span>{% elsif post.tags contains "fitness" %}<span class="cat-badge fitness">fitness</span>{% elsif post.tags contains "project" or post.tags contains "facts and data" %}<span class="cat-badge project">project</span>{% endif %}
+                </li>
+              {% endfor %}
+            </ul>
+          </div>
+        {% endif %}
+      {% endfor %}
+    </div>
+
+  </div><!-- #view-bydate -->
+
 </section>
 
 <script>
 (function() {
-  var tabs = document.querySelectorAll('.cat-tab');
-  var sections = document.querySelectorAll('.cat-section');
-  var labels = document.querySelectorAll('.cat-section-label');
+  var viewPicker    = document.getElementById('view-picker');
+  var viewPickBtn   = document.getElementById('view-pick-btn');
+  var viewPickLabel = document.getElementById('view-pick-label');
+  var viewOptions   = document.querySelectorAll('.view-option');
+  var viewTierlist  = document.getElementById('view-tierlist');
+  var viewBydate    = document.getElementById('view-bydate');
+  var catPicker     = document.getElementById('cat-picker');
+  var catPickBtn    = document.getElementById('cat-pick-btn');
+  var catOptions    = document.querySelectorAll('.cat-option');
+
+  var currentView = 'tierlist';
+  var currentCat  = 'all';
 
   function showCat(cat) {
-    sections.forEach(function(s) {
+    currentCat = cat;
+    var container = currentView === 'tierlist' ? viewTierlist : viewBydate;
+    container.querySelectorAll('.cat-section').forEach(function(s) {
       s.style.display = s.dataset.cat === cat ? '' : 'none';
     });
-    labels.forEach(function(l) { l.style.display = 'none'; });
   }
 
-  // Default to stories on load
-  showCat('stories');
+  function showView(view) {
+    currentView = view;
+    viewTierlist.style.display = view === 'tierlist' ? '' : 'none';
+    viewBydate.style.display   = view === 'bydate'   ? '' : 'none';
+    showCat(currentCat);
+  }
 
-  tabs.forEach(function(tab) {
-    tab.addEventListener('click', function() {
-      tabs.forEach(function(t) { t.classList.remove('active'); });
+  showView('tierlist');
+  showCat('all');
+
+  viewPickBtn.addEventListener('click', function(e) {
+    e.stopPropagation();
+    var opening = !viewPicker.classList.contains('open');
+    viewPicker.classList.toggle('open');
+    viewPickBtn.setAttribute('aria-expanded', opening ? 'true' : 'false');
+  });
+
+  viewOptions.forEach(function(opt) {
+    opt.addEventListener('click', function(e) {
+      e.stopPropagation();
+      viewPickLabel.textContent = this.dataset.label;
+      viewPickBtn.setAttribute('aria-expanded', 'false');
+      viewPicker.classList.remove('open');
+      viewOptions.forEach(function(o) { o.classList.remove('active'); });
+      this.classList.add('active');
+      showView(this.dataset.view);
+    });
+  });
+
+  catPickBtn.addEventListener('click', function(e) {
+    e.stopPropagation();
+    var opening = !catPicker.classList.contains('open');
+    catPicker.classList.toggle('open');
+    catPickBtn.setAttribute('aria-expanded', opening ? 'true' : 'false');
+  });
+
+  catOptions.forEach(function(opt) {
+    opt.addEventListener('click', function(e) {
+      e.stopPropagation();
+      catPickBtn.setAttribute('aria-label', 'Filter: ' + this.textContent.trim());
+      catPickBtn.setAttribute('aria-expanded', 'false');
+      catPicker.classList.remove('open');
+      catOptions.forEach(function(o) { o.classList.remove('active'); });
       this.classList.add('active');
       showCat(this.dataset.cat);
     });
   });
+
+  document.addEventListener('click', function() {
+    viewPicker.classList.remove('open');
+    viewPickBtn.setAttribute('aria-expanded', 'false');
+    catPicker.classList.remove('open');
+    catPickBtn.setAttribute('aria-expanded', 'false');
+  });
 })();
 </script>
-
-<section id="archive">
-  <div class="section-label">All</div>
-  {% assign posts_by_year = site.posts | group_by_exp: "post", "post.date | date: '%Y'" %}
-  {% for year_group in posts_by_year %}
-    <div class="year-group">
-      <div class="year-label">{{ year_group.name }}</div>
-      <ul class="posts">
-        {% for post in year_group.items %}
-          <li>
-            <span class="post-date">{{ post.date | date: "%-d %b" }}</span>
-            <a href="{{ post.url }}" title="{{ post.title }}">{{ post.title }}</a>
-          </li>
-        {% endfor %}
-      </ul>
-    </div>
-  {% endfor %}
-</section>


### PR DESCRIPTION
… masthead

- Homepage reorganised as tier list (S–F + notes) with category filter (All/Stories/Grow/Essays/Fitness/Project)
- Added by-date archive view switchable via heading picker dropdown
- Category badges on post items use typographic differentiation (no colour chips)
- Masthead centred and enlarged; view-picker styled as indented section heading
- Renamed 'projects' tag to 'project' across posts
- Fixed blockquote line-break rendering in post styles